### PR TITLE
Add localization infrastructure and shared UI components

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -70,6 +70,9 @@ _Avoid_: Locked, closed forever
 
 **Typography scale**: Three levels — `title` (28px/700), `body` (16px/400), `label` (12px/600, uppercase).
 
+**Spacing scale**: Named stops exported from `src/theme/` — `xs` (8), `sm` (12), `md` (16), `lg` (20), `xl` (24), `xxl` (32). All padding, margin, and gap values must reference the scale. Border radius is a per-component decision and does not use the scale.
+_Avoid_: Raw numbers for spacing, a numeric multiplier function
+
 **Buttons**: Two variants — `primary` (black background, white text) and `secondary` (white background, black border and text). Pure black/white enforces the wireframe constraint and avoids color debates.
 
 **Light/dark mode**: The `src/theme/` folder structure is intentional — exporting named token objects makes it straightforward to add a dark theme later without restructuring.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -62,6 +62,23 @@ _Avoid_: Locked, closed forever
 > **Dev:** "If Anna paid for dinner for Anna, Ben, and Clara, is that one **Transfer** or one **Expense**?"
 > **Domain expert:** "That is one **Expense** in the **Ledger**. The app stores one **Expense allocation** per **Participant**, derives each **Balance**, and later suggests **Transfers** during **Settlement**."
 
+## Design system
+
+**Theme**: Centralised style tokens in `src/theme/index.ts`. All screens import from there — no page-level StyleSheet allowed. If a value appears in more than one file it belongs in the theme.
+
+**Color palette**: Black-to-white only (`#000000` → `#ffffff` with semantic gray stops). No strong color by design — the UI intentionally reads as a wireframe placeholder until a real visual design is applied.
+
+**Typography scale**: Three levels — `title` (28px/700), `body` (16px/400), `label` (12px/600, uppercase).
+
+**Buttons**: Two variants — `primary` (black background, white text) and `secondary` (white background, black border and text). Pure black/white enforces the wireframe constraint and avoids color debates.
+
+**Light/dark mode**: The `src/theme/` folder structure is intentional — exporting named token objects makes it straightforward to add a dark theme later without restructuring.
+
+## Localization
+
+**Locale resolution**: The active locale is determined in priority order: (1) user-selected language from the in-app picker, (2) device system language via `expo-localization`, (3) English hard fallback. Translation strings live in per-locale JSON files; adding a language requires no code changes.
+_Avoid_: Language detection, auto-detect only
+
 ## Flagged ambiguities
 
 - "user" was used to mean **Participant**; resolved: v1 has no account system, only ledger-local **Participants**.

--- a/app.json
+++ b/app.json
@@ -12,6 +12,6 @@
     "android": {
       "predictiveBackGestureEnabled": false
     },
-    "plugins": ["expo-router"]
+    "plugins": ["expo-router", "expo-localization"]
   }
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,8 @@
 import { Stack } from 'expo-router';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { initI18n } from '../src/i18n';
+
+initI18n();
 
 export default function RootLayout() {
   return (

--- a/docs/adr/0002-localization-strategy.md
+++ b/docs/adr/0002-localization-strategy.md
@@ -1,0 +1,34 @@
+# ADR 0002: Localization strategy
+
+## Status
+
+Accepted
+
+## Context
+
+The app launches in English only but needs to be structured so adding new locales later is a file-copy-and-translate operation rather than a refactor. The Expo localization docs recommend pairing `expo-localization` (device locale detection) with a translation library. The realistic candidates were:
+
+- **react-i18next** — explicit React Native support, JSON files, large ecosystem
+- **LinguiJS** — compile-time extraction, PO files, better for professional translators
+- **react-intl (FormatJS)** — ICU message format, web-first with unclear React Native support
+- **i18n-js** — lightweight, smaller ecosystem
+
+Locale resolution must follow a three-tier priority: in-app language picker → device system language (via `expo-localization`) → English fallback.
+
+## Decision
+
+Use `expo-localization` + `react-i18next`.
+
+Locale resolution order:
+
+1. User-selected language stored in app state (in-app picker)
+2. `expo-localization.getLocales()[0].languageTag` (device system language)
+3. `"en"` hard fallback
+
+## Consequences
+
+- One JSON file per locale (`en.json`, etc.) — adding a language is a translate-and-add-file operation with no code changes needed.
+- `react-i18next` is initialised at app startup with the resolved locale; the in-app picker updates the i18next instance and persists the choice.
+- LinguiJS's compile step and PO toolchain are avoided — appropriate since translations are done by the developer, not external translators.
+- react-intl is avoided due to undocumented React Native support.
+- Migrating away from react-i18next later would require replacing all `useTranslation()` call sites and the translation file format.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,25 +8,28 @@
       "name": "coinsplit",
       "version": "1.0.0",
       "dependencies": {
-        "expo": "^55.0.23",
-        "expo-constants": "^55.0.16",
-        "expo-linking": "^55.0.15",
-        "expo-router": "^55.0.14",
-        "expo-status-bar": "^55.0.6",
+        "expo": "55.0.23",
+        "expo-constants": "55.0.16",
+        "expo-linking": "55.0.15",
+        "expo-localization": "~55.0.13",
+        "expo-router": "55.0.14",
+        "expo-status-bar": "55.0.6",
+        "i18next": "^26.0.10",
         "react": "19.2.0",
-        "react-native": "^0.83.6",
-        "react-native-safe-area-context": "~5.6.2",
-        "react-native-screens": "~4.23.0"
+        "react-i18next": "^17.0.7",
+        "react-native": "0.83.6",
+        "react-native-safe-area-context": "5.6.2",
+        "react-native-screens": "4.23.0"
       },
       "devDependencies": {
-        "@ai-hero/sandcastle": "^0.5.7",
-        "@types/react": "~19.2.10",
-        "eslint": "^9.39.4",
-        "eslint-config-expo": "^55.0.0",
-        "husky": "^9.1.7",
-        "lint-staged": "^16.4.0",
-        "prettier": "^3.8.3",
-        "typescript": "~5.9.2"
+        "@ai-hero/sandcastle": "0.5.7",
+        "@types/react": "19.2.14",
+        "eslint": "9.39.4",
+        "eslint-config-expo": "55.0.0",
+        "husky": "9.1.7",
+        "lint-staged": "16.4.0",
+        "prettier": "3.8.3",
+        "typescript": "5.9.3"
       }
     },
     "node_modules/@ai-hero/sandcastle": {
@@ -6675,6 +6678,19 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-localization": {
+      "version": "55.0.13",
+      "resolved": "https://registry.npmjs.org/expo-localization/-/expo-localization-55.0.13.tgz",
+      "integrity": "sha512-fXiEUUihIrXmAEzoneaTOFcQ7TKmr25RR/ymrB/MvYTVnmevFA1zY2KI0VSiXY+NKKjZ8mG65YSn1wh4gEYKxA==",
+      "license": "MIT",
+      "dependencies": {
+        "rtl-detect": "^1.0.2"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "55.0.21",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-55.0.21.tgz",
@@ -7965,6 +7981,15 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -8021,6 +8046,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "26.0.10",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.10.tgz",
+      "integrity": "sha512-k3yGPAlWR2RdMYoVXJoDZDT87qeHIWKH7gVksdZMpRty7QX/D9QZeYGvN08KGbKHke9wn01eYT+EEsrqX/YTlw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://www.locize.com/i18next"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/ignore": {
@@ -11243,6 +11296,33 @@
         "react": ">=17.0.0"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "17.0.7",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.7.tgz",
+      "integrity": "sha512-rwtPXsb/zwzDafN+gytcjF5YnqGQQIRmCQ6DctBC1VSipRB8GD/MWEVrFP42vjMyuYydxWxM8CZRt+yiNuuoHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 26.0.10",
+        "react": ">= 16.8.0",
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -11763,6 +11843,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/rtl-detect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rtl-detect/-/rtl-detect-1.1.2.tgz",
+      "integrity": "sha512-PGMBq03+TTG/p/cRB7HCLKJ1MgDIi07+QU1faSjiYRfmY5UsAttV9Hs08jDAHVwcOwmVLcSJkpwyfXszVjWfIQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.4",
@@ -13419,6 +13505,15 @@
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
       "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
       "license": "MIT"
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/walker": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,12 @@
     "expo": "55.0.23",
     "expo-constants": "55.0.16",
     "expo-linking": "55.0.15",
+    "expo-localization": "~55.0.13",
     "expo-router": "55.0.14",
     "expo-status-bar": "55.0.6",
+    "i18next": "^26.0.10",
     "react": "19.2.0",
+    "react-i18next": "^17.0.7",
     "react-native": "0.83.6",
     "react-native-safe-area-context": "5.6.2",
     "react-native-screens": "4.23.0"

--- a/src/components/BodyText.tsx
+++ b/src/components/BodyText.tsx
@@ -1,0 +1,6 @@
+import { Text, TextProps } from 'react-native';
+import { typography } from '../theme';
+
+export default function BodyText({ style, ...rest }: TextProps) {
+  return <Text style={[typography.body, style]} {...rest} />;
+}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,16 @@
+import { Text, TouchableOpacity, TouchableOpacityProps } from 'react-native';
+import { buttons } from '../theme';
+
+type Props = TouchableOpacityProps & {
+  label: string;
+  variant?: 'primary' | 'secondary';
+};
+
+export default function Button({ label, variant = 'primary', style, ...rest }: Props) {
+  const styles = buttons[variant];
+  return (
+    <TouchableOpacity style={[styles.container, style]} {...rest}>
+      <Text style={styles.label}>{label}</Text>
+    </TouchableOpacity>
+  );
+}

--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -1,0 +1,6 @@
+import { Text, TextProps } from 'react-native';
+import { typography } from '../theme';
+
+export default function Label({ style, ...rest }: TextProps) {
+  return <Text style={[typography.label, style]} {...rest} />;
+}

--- a/src/components/Title.tsx
+++ b/src/components/Title.tsx
@@ -1,0 +1,6 @@
+import { Text, TextProps } from 'react-native';
+import { typography } from '../theme';
+
+export default function Title({ style, ...rest }: TextProps) {
+  return <Text style={[typography.title, style]} {...rest} />;
+}

--- a/src/features/expenseForm/ExpenseFormScreen.tsx
+++ b/src/features/expenseForm/ExpenseFormScreen.tsx
@@ -1,11 +1,15 @@
 import { router, useLocalSearchParams } from 'expo-router';
-import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { ScrollView, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import Button from '../../components/Button';
+import Title from '../../components/Title';
+import { colors } from '../../theme';
 
 export default function ExpenseFormScreen() {
   const { expenseId } = useLocalSearchParams<{ id: string; expenseId?: string }>();
+  const { t } = useTranslation();
   const isEdit = !!expenseId;
-  const title = isEdit ? 'Edit Expense' : 'New Expense';
 
   function handleSave() {
     router.dismiss();
@@ -16,45 +20,13 @@ export default function ExpenseFormScreen() {
   }
 
   return (
-    <SafeAreaView style={styles.screen}>
-      <ScrollView contentContainerStyle={styles.content}>
-        <Text style={styles.title}>{title}</Text>
-        <View style={styles.spacer} />
-        <TouchableOpacity style={styles.primaryButton} onPress={handleSave}>
-          <Text style={styles.primaryButtonLabel}>Save</Text>
-        </TouchableOpacity>
-        <TouchableOpacity style={styles.secondaryButton} onPress={handleCancel}>
-          <Text style={styles.secondaryButtonLabel}>Cancel</Text>
-        </TouchableOpacity>
+    <SafeAreaView style={{ flex: 1, backgroundColor: colors.background }}>
+      <ScrollView contentContainerStyle={{ flexGrow: 1, paddingHorizontal: 24, paddingVertical: 32, gap: 12 }}>
+        <Title style={{ marginBottom: 8 }}>{isEdit ? t('expenseForm.titleEdit') : t('expenseForm.titleNew')}</Title>
+        <View style={{ flex: 1 }} />
+        <Button label={t('common.save')} onPress={handleSave} />
+        <Button label={t('common.cancel')} variant="secondary" onPress={handleCancel} />
       </ScrollView>
     </SafeAreaView>
   );
 }
-
-const styles = StyleSheet.create({
-  screen: { flex: 1, backgroundColor: '#f8fafc' },
-  content: {
-    flexGrow: 1,
-    paddingHorizontal: 24,
-    paddingVertical: 32,
-    gap: 12,
-  },
-  title: { fontSize: 28, fontWeight: '700', color: '#0f172a', marginBottom: 8 },
-  spacer: { flex: 1 },
-  primaryButton: {
-    backgroundColor: '#0f172a',
-    borderRadius: 14,
-    paddingVertical: 16,
-    alignItems: 'center',
-  },
-  primaryButtonLabel: { color: '#ffffff', fontSize: 16, fontWeight: '600' },
-  secondaryButton: {
-    backgroundColor: '#ffffff',
-    borderRadius: 14,
-    paddingVertical: 16,
-    alignItems: 'center',
-    borderWidth: 1,
-    borderColor: '#e2e8f0',
-  },
-  secondaryButtonLabel: { color: '#0f172a', fontSize: 16, fontWeight: '500' },
-});

--- a/src/features/expenseForm/ExpenseFormScreen.tsx
+++ b/src/features/expenseForm/ExpenseFormScreen.tsx
@@ -4,7 +4,7 @@ import { ScrollView, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Button from '../../components/Button';
 import Title from '../../components/Title';
-import { colors } from '../../theme';
+import { colors, spacing } from '../../theme';
 
 export default function ExpenseFormScreen() {
   const { expenseId } = useLocalSearchParams<{ id: string; expenseId?: string }>();
@@ -21,8 +21,17 @@ export default function ExpenseFormScreen() {
 
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: colors.background }}>
-      <ScrollView contentContainerStyle={{ flexGrow: 1, paddingHorizontal: 24, paddingVertical: 32, gap: 12 }}>
-        <Title style={{ marginBottom: 8 }}>{isEdit ? t('expenseForm.titleEdit') : t('expenseForm.titleNew')}</Title>
+      <ScrollView
+        contentContainerStyle={{
+          flexGrow: 1,
+          paddingHorizontal: spacing.xl,
+          paddingVertical: spacing.xxl,
+          gap: spacing.sm,
+        }}
+      >
+        <Title style={{ marginBottom: spacing.xs }}>
+          {isEdit ? t('expenseForm.titleEdit') : t('expenseForm.titleNew')}
+        </Title>
         <View style={{ flex: 1 }} />
         <Button label={t('common.save')} onPress={handleSave} />
         <Button label={t('common.cancel')} variant="secondary" onPress={handleCancel} />

--- a/src/features/ledgerDetail/LedgerDetailScreen.tsx
+++ b/src/features/ledgerDetail/LedgerDetailScreen.tsx
@@ -5,7 +5,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import Button from '../../components/Button';
 import Label from '../../components/Label';
 import Title from '../../components/Title';
-import { colors } from '../../theme';
+import { colors, spacing } from '../../theme';
 
 export default function LedgerDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -13,9 +13,16 @@ export default function LedgerDetailScreen() {
 
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: colors.background }}>
-      <ScrollView contentContainerStyle={{ flexGrow: 1, paddingHorizontal: 24, paddingVertical: 32, gap: 12 }}>
+      <ScrollView
+        contentContainerStyle={{
+          flexGrow: 1,
+          paddingHorizontal: spacing.xl,
+          paddingVertical: spacing.xxl,
+          gap: spacing.sm,
+        }}
+      >
         <Label>{t('ledgerDetail.label')}</Label>
-        <Title style={{ marginBottom: 8 }}>Summer Trip</Title>
+        <Title style={{ marginBottom: spacing.xs }}>Summer Trip</Title>
 
         <Button label={t('ledgerDetail.newExpense')} onPress={() => router.push(`/ledger/${id}/expense/new`)} />
         <Button label={t('ledgerDetail.newTransfer')} onPress={() => router.push(`/ledger/${id}/transfer/new`)} />

--- a/src/features/ledgerDetail/LedgerDetailScreen.tsx
+++ b/src/features/ledgerDetail/LedgerDetailScreen.tsx
@@ -1,66 +1,35 @@
 import { router, useLocalSearchParams } from 'expo-router';
-import { ScrollView, StyleSheet, Text, TouchableOpacity } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import Button from '../../components/Button';
+import Label from '../../components/Label';
+import Title from '../../components/Title';
+import { colors } from '../../theme';
 
 export default function LedgerDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
+  const { t } = useTranslation();
 
   return (
-    <SafeAreaView style={styles.screen}>
-      <ScrollView contentContainerStyle={styles.content}>
-        <Text style={styles.eyebrow}>Ledger</Text>
-        <Text style={styles.title}>Summer Trip</Text>
+    <SafeAreaView style={{ flex: 1, backgroundColor: colors.background }}>
+      <ScrollView contentContainerStyle={{ flexGrow: 1, paddingHorizontal: 24, paddingVertical: 32, gap: 12 }}>
+        <Label>{t('ledgerDetail.label')}</Label>
+        <Title style={{ marginBottom: 8 }}>Summer Trip</Title>
 
-        <TouchableOpacity style={styles.primaryButton} onPress={() => router.push(`/ledger/${id}/expense/new`)}>
-          <Text style={styles.primaryButtonLabel}>New Expense</Text>
-        </TouchableOpacity>
-
-        <TouchableOpacity style={styles.primaryButton} onPress={() => router.push(`/ledger/${id}/transfer/new`)}>
-          <Text style={styles.primaryButtonLabel}>New Transfer</Text>
-        </TouchableOpacity>
-
-        <TouchableOpacity style={styles.secondaryButton} onPress={() => router.push(`/ledger/${id}/settlement`)}>
-          <Text style={styles.secondaryButtonLabel}>Settlement</Text>
-        </TouchableOpacity>
-
-        <TouchableOpacity style={styles.secondaryButton} onPress={() => router.push(`/ledger/${id}/edit`)}>
-          <Text style={styles.secondaryButtonLabel}>Edit Ledger</Text>
-        </TouchableOpacity>
+        <Button label={t('ledgerDetail.newExpense')} onPress={() => router.push(`/ledger/${id}/expense/new`)} />
+        <Button label={t('ledgerDetail.newTransfer')} onPress={() => router.push(`/ledger/${id}/transfer/new`)} />
+        <Button
+          label={t('ledgerDetail.settlement')}
+          variant="secondary"
+          onPress={() => router.push(`/ledger/${id}/settlement`)}
+        />
+        <Button
+          label={t('ledgerDetail.editLedger')}
+          variant="secondary"
+          onPress={() => router.push(`/ledger/${id}/edit`)}
+        />
       </ScrollView>
     </SafeAreaView>
   );
 }
-
-const styles = StyleSheet.create({
-  screen: { flex: 1, backgroundColor: '#f8fafc' },
-  content: {
-    flexGrow: 1,
-    paddingHorizontal: 24,
-    paddingVertical: 32,
-    gap: 12,
-  },
-  eyebrow: {
-    fontSize: 14,
-    fontWeight: '600',
-    letterSpacing: 1,
-    textTransform: 'uppercase',
-    color: '#64748b',
-  },
-  title: { fontSize: 32, fontWeight: '700', color: '#0f172a', marginBottom: 8 },
-  primaryButton: {
-    backgroundColor: '#0f172a',
-    borderRadius: 14,
-    paddingVertical: 16,
-    alignItems: 'center',
-  },
-  primaryButtonLabel: { color: '#ffffff', fontSize: 16, fontWeight: '600' },
-  secondaryButton: {
-    backgroundColor: '#ffffff',
-    borderRadius: 14,
-    paddingVertical: 16,
-    alignItems: 'center',
-    borderWidth: 1,
-    borderColor: '#e2e8f0',
-  },
-  secondaryButtonLabel: { color: '#0f172a', fontSize: 16, fontWeight: '500' },
-});

--- a/src/features/ledgerForm/LedgerFormScreen.tsx
+++ b/src/features/ledgerForm/LedgerFormScreen.tsx
@@ -1,11 +1,15 @@
 import { router, useLocalSearchParams } from 'expo-router';
-import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { ScrollView, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import Button from '../../components/Button';
+import Title from '../../components/Title';
+import { colors } from '../../theme';
 
 export default function LedgerFormScreen() {
   const { id } = useLocalSearchParams<{ id?: string }>();
+  const { t } = useTranslation();
   const isEdit = !!id;
-  const title = isEdit ? 'Edit Ledger' : 'New Ledger';
 
   function handleSave() {
     if (router.canDismiss()) {
@@ -24,45 +28,13 @@ export default function LedgerFormScreen() {
   }
 
   return (
-    <SafeAreaView style={styles.screen}>
-      <ScrollView contentContainerStyle={styles.content}>
-        <Text style={styles.title}>{title}</Text>
-        <View style={styles.spacer} />
-        <TouchableOpacity style={styles.primaryButton} onPress={handleSave}>
-          <Text style={styles.primaryButtonLabel}>Save</Text>
-        </TouchableOpacity>
-        <TouchableOpacity style={styles.secondaryButton} onPress={handleCancel}>
-          <Text style={styles.secondaryButtonLabel}>Cancel</Text>
-        </TouchableOpacity>
+    <SafeAreaView style={{ flex: 1, backgroundColor: colors.background }}>
+      <ScrollView contentContainerStyle={{ flexGrow: 1, paddingHorizontal: 24, paddingVertical: 32, gap: 12 }}>
+        <Title style={{ marginBottom: 8 }}>{isEdit ? t('ledgerForm.titleEdit') : t('ledgerForm.titleNew')}</Title>
+        <View style={{ flex: 1 }} />
+        <Button label={t('common.save')} onPress={handleSave} />
+        <Button label={t('common.cancel')} variant="secondary" onPress={handleCancel} />
       </ScrollView>
     </SafeAreaView>
   );
 }
-
-const styles = StyleSheet.create({
-  screen: { flex: 1, backgroundColor: '#f8fafc' },
-  content: {
-    flexGrow: 1,
-    paddingHorizontal: 24,
-    paddingVertical: 32,
-    gap: 12,
-  },
-  title: { fontSize: 28, fontWeight: '700', color: '#0f172a', marginBottom: 8 },
-  spacer: { flex: 1 },
-  primaryButton: {
-    backgroundColor: '#0f172a',
-    borderRadius: 14,
-    paddingVertical: 16,
-    alignItems: 'center',
-  },
-  primaryButtonLabel: { color: '#ffffff', fontSize: 16, fontWeight: '600' },
-  secondaryButton: {
-    backgroundColor: '#ffffff',
-    borderRadius: 14,
-    paddingVertical: 16,
-    alignItems: 'center',
-    borderWidth: 1,
-    borderColor: '#e2e8f0',
-  },
-  secondaryButtonLabel: { color: '#0f172a', fontSize: 16, fontWeight: '500' },
-});

--- a/src/features/ledgerForm/LedgerFormScreen.tsx
+++ b/src/features/ledgerForm/LedgerFormScreen.tsx
@@ -4,7 +4,7 @@ import { ScrollView, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Button from '../../components/Button';
 import Title from '../../components/Title';
-import { colors } from '../../theme';
+import { colors, spacing } from '../../theme';
 
 export default function LedgerFormScreen() {
   const { id } = useLocalSearchParams<{ id?: string }>();
@@ -29,8 +29,17 @@ export default function LedgerFormScreen() {
 
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: colors.background }}>
-      <ScrollView contentContainerStyle={{ flexGrow: 1, paddingHorizontal: 24, paddingVertical: 32, gap: 12 }}>
-        <Title style={{ marginBottom: 8 }}>{isEdit ? t('ledgerForm.titleEdit') : t('ledgerForm.titleNew')}</Title>
+      <ScrollView
+        contentContainerStyle={{
+          flexGrow: 1,
+          paddingHorizontal: spacing.xl,
+          paddingVertical: spacing.xxl,
+          gap: spacing.sm,
+        }}
+      >
+        <Title style={{ marginBottom: spacing.xs }}>
+          {isEdit ? t('ledgerForm.titleEdit') : t('ledgerForm.titleNew')}
+        </Title>
         <View style={{ flex: 1 }} />
         <Button label={t('common.save')} onPress={handleSave} />
         <Button label={t('common.cancel')} variant="secondary" onPress={handleCancel} />

--- a/src/features/ledgerList/LedgerListScreen.tsx
+++ b/src/features/ledgerList/LedgerListScreen.tsx
@@ -1,114 +1,59 @@
 import { router } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
-import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { ScrollView, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import BodyText from '../../components/BodyText';
+import Button from '../../components/Button';
+import Label from '../../components/Label';
+import Title from '../../components/Title';
+import { colors } from '../../theme';
 
 const PLACEHOLDER_LEDGER_ID = 'placeholder';
 
 export default function LedgerListScreen() {
-  return (
-    <SafeAreaView style={styles.screen}>
-      <StatusBar style="dark" />
-      <ScrollView contentContainerStyle={styles.content}>
-        <Text style={styles.eyebrow}>Coinsplit</Text>
-        <Text style={styles.title}>Ledgers</Text>
+  const { t } = useTranslation();
 
-        <View style={styles.card}>
-          <Text style={styles.cardTitle}>No ledgers yet</Text>
-          <Text style={styles.cardBody}>
-            Create a ledger to start tracking participants, expenses, and transfers for your next shared event.
-          </Text>
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: colors.background }}>
+      <StatusBar style="dark" />
+      <ScrollView contentContainerStyle={{ flexGrow: 1, paddingHorizontal: 24, paddingVertical: 32, gap: 16 }}>
+        <Label>{t('ledgerList.appName')}</Label>
+        <Title>{t('ledgerList.title')}</Title>
+
+        <View
+          style={{
+            borderRadius: 20,
+            padding: 20,
+            backgroundColor: colors.surface,
+            borderWidth: 1,
+            borderColor: colors.border,
+          }}
+        >
+          <BodyText style={{ fontWeight: '600', marginBottom: 8 }}>{t('ledgerList.empty.heading')}</BodyText>
+          <BodyText style={{ color: colors.text.secondary, lineHeight: 24 }}>{t('ledgerList.empty.body')}</BodyText>
         </View>
 
-        <TouchableOpacity style={styles.placeholderRow} onPress={() => router.push(`/ledger/${PLACEHOLDER_LEDGER_ID}`)}>
-          <Text style={styles.placeholderRowTitle}>Summer Trip</Text>
-          <Text style={styles.placeholderRowChevron}>›</Text>
+        <TouchableOpacity
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            backgroundColor: colors.surface,
+            borderRadius: 14,
+            paddingHorizontal: 20,
+            paddingVertical: 16,
+            borderWidth: 1,
+            borderColor: colors.border,
+          }}
+          onPress={() => router.push(`/ledger/${PLACEHOLDER_LEDGER_ID}`)}
+        >
+          <BodyText style={{ fontWeight: '500' }}>Summer Trip</BodyText>
+          <BodyText style={{ fontSize: 22, color: colors.text.tertiary }}>›</BodyText>
         </TouchableOpacity>
 
-        <TouchableOpacity style={styles.primaryButton} onPress={() => router.push('/ledger/new')}>
-          <Text style={styles.primaryButtonLabel}>New Ledger</Text>
-        </TouchableOpacity>
+        <Button label={t('ledgerList.newLedger')} style={{ marginTop: 8 }} onPress={() => router.push('/ledger/new')} />
       </ScrollView>
     </SafeAreaView>
   );
 }
-
-const styles = StyleSheet.create({
-  screen: {
-    flex: 1,
-    backgroundColor: '#f8fafc',
-  },
-  content: {
-    flexGrow: 1,
-    paddingHorizontal: 24,
-    paddingVertical: 32,
-    gap: 16,
-  },
-  eyebrow: {
-    fontSize: 14,
-    fontWeight: '600',
-    letterSpacing: 1,
-    textTransform: 'uppercase',
-    color: '#64748b',
-  },
-  title: {
-    fontSize: 32,
-    fontWeight: '700',
-    color: '#0f172a',
-  },
-  card: {
-    borderRadius: 20,
-    padding: 20,
-    backgroundColor: '#ffffff',
-    borderWidth: 1,
-    borderColor: '#e2e8f0',
-    shadowColor: '#0f172a',
-    shadowOpacity: 0.08,
-    shadowRadius: 12,
-    shadowOffset: { width: 0, height: 4 },
-    elevation: 2,
-  },
-  cardTitle: {
-    fontSize: 20,
-    fontWeight: '600',
-    color: '#0f172a',
-    marginBottom: 8,
-  },
-  cardBody: {
-    fontSize: 16,
-    lineHeight: 24,
-    color: '#475569',
-  },
-  placeholderRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    backgroundColor: '#ffffff',
-    borderRadius: 14,
-    paddingHorizontal: 20,
-    paddingVertical: 16,
-    borderWidth: 1,
-    borderColor: '#e2e8f0',
-  },
-  placeholderRowTitle: {
-    fontSize: 16,
-    fontWeight: '500',
-    color: '#0f172a',
-  },
-  placeholderRowChevron: {
-    fontSize: 22,
-    color: '#94a3b8',
-  },
-  primaryButton: {
-    backgroundColor: '#0f172a',
-    borderRadius: 14,
-    paddingVertical: 16,
-    alignItems: 'center',
-    marginTop: 8,
-  },
-  primaryButtonLabel: {
-    color: '#ffffff',
-    fontSize: 16,
-    fontWeight: '600',
-  },
-});

--- a/src/features/ledgerList/LedgerListScreen.tsx
+++ b/src/features/ledgerList/LedgerListScreen.tsx
@@ -7,7 +7,7 @@ import BodyText from '../../components/BodyText';
 import Button from '../../components/Button';
 import Label from '../../components/Label';
 import Title from '../../components/Title';
-import { colors } from '../../theme';
+import { colors, spacing } from '../../theme';
 
 const PLACEHOLDER_LEDGER_ID = 'placeholder';
 
@@ -17,20 +17,27 @@ export default function LedgerListScreen() {
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: colors.background }}>
       <StatusBar style="dark" />
-      <ScrollView contentContainerStyle={{ flexGrow: 1, paddingHorizontal: 24, paddingVertical: 32, gap: 16 }}>
+      <ScrollView
+        contentContainerStyle={{
+          flexGrow: 1,
+          paddingHorizontal: spacing.xl,
+          paddingVertical: spacing.xxl,
+          gap: spacing.md,
+        }}
+      >
         <Label>{t('ledgerList.appName')}</Label>
         <Title>{t('ledgerList.title')}</Title>
 
         <View
           style={{
             borderRadius: 20,
-            padding: 20,
+            padding: spacing.lg,
             backgroundColor: colors.surface,
             borderWidth: 1,
             borderColor: colors.border,
           }}
         >
-          <BodyText style={{ fontWeight: '600', marginBottom: 8 }}>{t('ledgerList.empty.heading')}</BodyText>
+          <BodyText style={{ fontWeight: '600', marginBottom: spacing.xs }}>{t('ledgerList.empty.heading')}</BodyText>
           <BodyText style={{ color: colors.text.secondary, lineHeight: 24 }}>{t('ledgerList.empty.body')}</BodyText>
         </View>
 
@@ -41,8 +48,8 @@ export default function LedgerListScreen() {
             justifyContent: 'space-between',
             backgroundColor: colors.surface,
             borderRadius: 14,
-            paddingHorizontal: 20,
-            paddingVertical: 16,
+            paddingHorizontal: spacing.lg,
+            paddingVertical: spacing.md,
             borderWidth: 1,
             borderColor: colors.border,
           }}
@@ -52,7 +59,11 @@ export default function LedgerListScreen() {
           <BodyText style={{ fontSize: 22, color: colors.text.tertiary }}>›</BodyText>
         </TouchableOpacity>
 
-        <Button label={t('ledgerList.newLedger')} style={{ marginTop: 8 }} onPress={() => router.push('/ledger/new')} />
+        <Button
+          label={t('ledgerList.newLedger')}
+          style={{ marginTop: spacing.xs }}
+          onPress={() => router.push('/ledger/new')}
+        />
       </ScrollView>
     </SafeAreaView>
   );

--- a/src/features/settlementView/SettlementViewScreen.tsx
+++ b/src/features/settlementView/SettlementViewScreen.tsx
@@ -5,16 +5,23 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import Button from '../../components/Button';
 import Label from '../../components/Label';
 import Title from '../../components/Title';
-import { colors } from '../../theme';
+import { colors, spacing } from '../../theme';
 
 export default function SettlementViewScreen() {
   const { t } = useTranslation();
 
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: colors.background }}>
-      <ScrollView contentContainerStyle={{ flexGrow: 1, paddingHorizontal: 24, paddingVertical: 32, gap: 12 }}>
+      <ScrollView
+        contentContainerStyle={{
+          flexGrow: 1,
+          paddingHorizontal: spacing.xl,
+          paddingVertical: spacing.xxl,
+          gap: spacing.sm,
+        }}
+      >
         <Label>{t('settlementView.label')}</Label>
-        <Title style={{ marginBottom: 8 }}>{t('settlementView.title')}</Title>
+        <Title style={{ marginBottom: spacing.xs }}>{t('settlementView.title')}</Title>
         <Button label={t('settlementView.backToLedger')} variant="secondary" onPress={() => router.back()} />
       </ScrollView>
     </SafeAreaView>

--- a/src/features/settlementView/SettlementViewScreen.tsx
+++ b/src/features/settlementView/SettlementViewScreen.tsx
@@ -1,44 +1,22 @@
 import { router } from 'expo-router';
-import { ScrollView, StyleSheet, Text, TouchableOpacity } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import Button from '../../components/Button';
+import Label from '../../components/Label';
+import Title from '../../components/Title';
+import { colors } from '../../theme';
 
 export default function SettlementViewScreen() {
+  const { t } = useTranslation();
+
   return (
-    <SafeAreaView style={styles.screen}>
-      <ScrollView contentContainerStyle={styles.content}>
-        <Text style={styles.eyebrow}>Ledger</Text>
-        <Text style={styles.title}>Settlement</Text>
-        <TouchableOpacity style={styles.secondaryButton} onPress={() => router.back()}>
-          <Text style={styles.secondaryButtonLabel}>Back to Ledger</Text>
-        </TouchableOpacity>
+    <SafeAreaView style={{ flex: 1, backgroundColor: colors.background }}>
+      <ScrollView contentContainerStyle={{ flexGrow: 1, paddingHorizontal: 24, paddingVertical: 32, gap: 12 }}>
+        <Label>{t('settlementView.label')}</Label>
+        <Title style={{ marginBottom: 8 }}>{t('settlementView.title')}</Title>
+        <Button label={t('settlementView.backToLedger')} variant="secondary" onPress={() => router.back()} />
       </ScrollView>
     </SafeAreaView>
   );
 }
-
-const styles = StyleSheet.create({
-  screen: { flex: 1, backgroundColor: '#f8fafc' },
-  content: {
-    flexGrow: 1,
-    paddingHorizontal: 24,
-    paddingVertical: 32,
-    gap: 12,
-  },
-  eyebrow: {
-    fontSize: 14,
-    fontWeight: '600',
-    letterSpacing: 1,
-    textTransform: 'uppercase',
-    color: '#64748b',
-  },
-  title: { fontSize: 32, fontWeight: '700', color: '#0f172a', marginBottom: 8 },
-  secondaryButton: {
-    backgroundColor: '#ffffff',
-    borderRadius: 14,
-    paddingVertical: 16,
-    alignItems: 'center',
-    borderWidth: 1,
-    borderColor: '#e2e8f0',
-  },
-  secondaryButtonLabel: { color: '#0f172a', fontSize: 16, fontWeight: '500' },
-});

--- a/src/features/transferForm/TransferFormScreen.tsx
+++ b/src/features/transferForm/TransferFormScreen.tsx
@@ -4,7 +4,7 @@ import { ScrollView, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Button from '../../components/Button';
 import Title from '../../components/Title';
-import { colors } from '../../theme';
+import { colors, spacing } from '../../theme';
 
 export default function TransferFormScreen() {
   const { transferId } = useLocalSearchParams<{ id: string; transferId?: string }>();
@@ -21,8 +21,17 @@ export default function TransferFormScreen() {
 
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: colors.background }}>
-      <ScrollView contentContainerStyle={{ flexGrow: 1, paddingHorizontal: 24, paddingVertical: 32, gap: 12 }}>
-        <Title style={{ marginBottom: 8 }}>{isEdit ? t('transferForm.titleEdit') : t('transferForm.titleNew')}</Title>
+      <ScrollView
+        contentContainerStyle={{
+          flexGrow: 1,
+          paddingHorizontal: spacing.xl,
+          paddingVertical: spacing.xxl,
+          gap: spacing.sm,
+        }}
+      >
+        <Title style={{ marginBottom: spacing.xs }}>
+          {isEdit ? t('transferForm.titleEdit') : t('transferForm.titleNew')}
+        </Title>
         <View style={{ flex: 1 }} />
         <Button label={t('common.save')} onPress={handleSave} />
         <Button label={t('common.cancel')} variant="secondary" onPress={handleCancel} />

--- a/src/features/transferForm/TransferFormScreen.tsx
+++ b/src/features/transferForm/TransferFormScreen.tsx
@@ -1,11 +1,15 @@
 import { router, useLocalSearchParams } from 'expo-router';
-import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { ScrollView, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import Button from '../../components/Button';
+import Title from '../../components/Title';
+import { colors } from '../../theme';
 
 export default function TransferFormScreen() {
   const { transferId } = useLocalSearchParams<{ id: string; transferId?: string }>();
+  const { t } = useTranslation();
   const isEdit = !!transferId;
-  const title = isEdit ? 'Edit Transfer' : 'New Transfer';
 
   function handleSave() {
     router.dismiss();
@@ -16,45 +20,13 @@ export default function TransferFormScreen() {
   }
 
   return (
-    <SafeAreaView style={styles.screen}>
-      <ScrollView contentContainerStyle={styles.content}>
-        <Text style={styles.title}>{title}</Text>
-        <View style={styles.spacer} />
-        <TouchableOpacity style={styles.primaryButton} onPress={handleSave}>
-          <Text style={styles.primaryButtonLabel}>Save</Text>
-        </TouchableOpacity>
-        <TouchableOpacity style={styles.secondaryButton} onPress={handleCancel}>
-          <Text style={styles.secondaryButtonLabel}>Cancel</Text>
-        </TouchableOpacity>
+    <SafeAreaView style={{ flex: 1, backgroundColor: colors.background }}>
+      <ScrollView contentContainerStyle={{ flexGrow: 1, paddingHorizontal: 24, paddingVertical: 32, gap: 12 }}>
+        <Title style={{ marginBottom: 8 }}>{isEdit ? t('transferForm.titleEdit') : t('transferForm.titleNew')}</Title>
+        <View style={{ flex: 1 }} />
+        <Button label={t('common.save')} onPress={handleSave} />
+        <Button label={t('common.cancel')} variant="secondary" onPress={handleCancel} />
       </ScrollView>
     </SafeAreaView>
   );
 }
-
-const styles = StyleSheet.create({
-  screen: { flex: 1, backgroundColor: '#f8fafc' },
-  content: {
-    flexGrow: 1,
-    paddingHorizontal: 24,
-    paddingVertical: 32,
-    gap: 12,
-  },
-  title: { fontSize: 28, fontWeight: '700', color: '#0f172a', marginBottom: 8 },
-  spacer: { flex: 1 },
-  primaryButton: {
-    backgroundColor: '#0f172a',
-    borderRadius: 14,
-    paddingVertical: 16,
-    alignItems: 'center',
-  },
-  primaryButtonLabel: { color: '#ffffff', fontSize: 16, fontWeight: '600' },
-  secondaryButton: {
-    backgroundColor: '#ffffff',
-    borderRadius: 14,
-    paddingVertical: 16,
-    alignItems: 'center',
-    borderWidth: 1,
-    borderColor: '#e2e8f0',
-  },
-  secondaryButtonLabel: { color: '#0f172a', fontSize: 16, fontWeight: '500' },
-});

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,31 @@
+import { getLocales } from 'expo-localization';
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+import en from './locales/en.json';
+
+export const SUPPORTED_LANGUAGES = ['en'] as const;
+export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+
+function resolveLocale(pickerLanguage: SupportedLanguage | null): SupportedLanguage {
+  if (pickerLanguage && SUPPORTED_LANGUAGES.includes(pickerLanguage)) {
+    return pickerLanguage;
+  }
+  const systemTag = getLocales()[0]?.languageCode ?? null;
+  if (systemTag && SUPPORTED_LANGUAGES.includes(systemTag as SupportedLanguage)) {
+    return systemTag as SupportedLanguage;
+  }
+  return 'en';
+}
+
+export function initI18n(pickerLanguage: SupportedLanguage | null = null) {
+  // eslint-disable-next-line import/no-named-as-default-member
+  i18n.use(initReactI18next).init({
+    lng: resolveLocale(pickerLanguage),
+    fallbackLng: 'en',
+    resources: { en: { translation: en } },
+    interpolation: { escapeValue: false },
+  });
+}
+
+export default i18n;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,0 +1,39 @@
+{
+  "common": {
+    "save": "Save",
+    "cancel": "Cancel"
+  },
+  "ledgerList": {
+    "appName": "Coinsplit",
+    "title": "Ledgers",
+    "empty": {
+      "heading": "No ledgers yet",
+      "body": "Create a ledger to start tracking participants, expenses, and transfers for your next shared event."
+    },
+    "newLedger": "New Ledger"
+  },
+  "ledgerDetail": {
+    "label": "Ledger",
+    "newExpense": "New Expense",
+    "newTransfer": "New Transfer",
+    "settlement": "Settlement",
+    "editLedger": "Edit Ledger"
+  },
+  "ledgerForm": {
+    "titleNew": "New Ledger",
+    "titleEdit": "Edit Ledger"
+  },
+  "expenseForm": {
+    "titleNew": "New Expense",
+    "titleEdit": "Edit Expense"
+  },
+  "transferForm": {
+    "titleNew": "New Transfer",
+    "titleEdit": "Edit Transfer"
+  },
+  "settlementView": {
+    "label": "Ledger",
+    "title": "Settlement",
+    "backToLedger": "Back to Ledger"
+  }
+}

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,3 +1,12 @@
+export const spacing = {
+  xs: 8,
+  sm: 12,
+  md: 16,
+  lg: 20,
+  xl: 24,
+  xxl: 32,
+} as const;
+
 export const colors = {
   background: '#ffffff',
   surface: '#f5f5f5',
@@ -34,8 +43,8 @@ export const buttons = {
   primary: {
     container: {
       backgroundColor: '#000000',
-      paddingVertical: 16,
-      paddingHorizontal: 24,
+      paddingVertical: spacing.md,
+      paddingHorizontal: spacing.xl,
       borderRadius: 16,
       alignItems: 'center' as const,
     },
@@ -48,8 +57,8 @@ export const buttons = {
   secondary: {
     container: {
       backgroundColor: '#ffffff',
-      paddingVertical: 16,
-      paddingHorizontal: 24,
+      paddingVertical: spacing.md,
+      paddingHorizontal: spacing.xl,
       borderRadius: 16,
       alignItems: 'center' as const,
       borderWidth: 1,

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,64 @@
+export const colors = {
+  background: '#ffffff',
+  surface: '#f5f5f5',
+  border: '#d4d4d4',
+  text: {
+    primary: '#000000',
+    secondary: '#525252',
+    tertiary: '#a3a3a3',
+    inverse: '#ffffff',
+  },
+} as const;
+
+export const typography = {
+  title: {
+    fontSize: 28,
+    fontWeight: '700' as const,
+    color: colors.text.primary,
+  },
+  body: {
+    fontSize: 16,
+    fontWeight: '400' as const,
+    color: colors.text.primary,
+  },
+  label: {
+    fontSize: 12,
+    fontWeight: '600' as const,
+    color: colors.text.secondary,
+    textTransform: 'uppercase' as const,
+    letterSpacing: 1,
+  },
+} as const;
+
+export const buttons = {
+  primary: {
+    container: {
+      backgroundColor: '#000000',
+      paddingVertical: 16,
+      paddingHorizontal: 24,
+      borderRadius: 16,
+      alignItems: 'center' as const,
+    },
+    label: {
+      fontSize: 16,
+      fontWeight: '600' as const,
+      color: '#ffffff',
+    },
+  },
+  secondary: {
+    container: {
+      backgroundColor: '#ffffff',
+      paddingVertical: 16,
+      paddingHorizontal: 24,
+      borderRadius: 16,
+      alignItems: 'center' as const,
+      borderWidth: 1,
+      borderColor: '#000000',
+    },
+    label: {
+      fontSize: 16,
+      fontWeight: '500' as const,
+      color: '#000000',
+    },
+  },
+} as const;


### PR DESCRIPTION
## Summary

- Installs `expo-localization` + `react-i18next`/`i18next` and wires up three-tier locale resolution: in-app picker → device system language → English fallback
- Extracts all UI strings into `src/i18n/locales/en.json`; adding a new language is a file-copy-and-translate operation with no code changes
- Introduces `Button`, `Title`, `Label`, and `BodyText` components backed by theme tokens, eliminating repeated inline style objects across screens
- Migrates all six feature screens to use `useTranslation()` + the new components
- Adds ADR 0002 documenting the localization strategy decision

## Test plan

- [x] App boots without errors on iOS/Android
- [x] All screen titles and button labels render correctly in English
- [x] TypeScript passes (`npx tsc --noEmit`)
- [x] Lint passes (`npx eslint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)